### PR TITLE
fix: extract username for non sso users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  username = lower(regex(".+:(?P<username>.*)", data.aws_caller_identity.current.user_id).username)
+  username = lower(regex(".+[:/](?P<username>.*)", data.aws_caller_identity.current.arn).username)
   ami_filters = {
     common = {
       "root-device-type" : "ebs",


### PR DESCRIPTION
fixes #11 

non sso user arn ends with `user/danp` while sso users endd with `...575518f174/danp`