### PR TITLE
fix: dont print the workspace name in tags if on the default one

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,12 +25,14 @@ locals {
       "name" : "amzn2-ami-hvm-2.0*"
     }
   }
+
   common_tags = merge({
-    "tf-workspace" : terraform.workspace
     "creator" : local.username
     "comment" : var.comment != "" ? var.comment : null
     },
-  var.additional_tags)
+    var.additional_tags,
+    terraform.workspace != "default" ? { "tf-workspace" : terraform.workspace } : {}
+  )
 }
 
 resource "random_string" "module_suffix" {


### PR DESCRIPTION
fixes #5